### PR TITLE
Basic MUI AppBar added with logos.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { Container } from '@mui/material'
 import { BrowserRouter, Routes, Route  } from 'react-router-dom'
 import './App.css'
 
+import { Navbar } from './components/Navbar'
 
 import { Home } from './pages/Home'
 import { Player } from './pages/Player'
@@ -10,12 +11,16 @@ import { Player } from './pages/Player'
 function App() {
 
   return (
-    <Container>
+    <Container disableGutters sx={{ margin: 0 }}>
       <BrowserRouter>
+
+        <Navbar />
+
         <Routes>
           <Route path='/' element={<Home />} />
           <Route path='/:id' element={<Player />} />
         </Routes>
+
       </BrowserRouter>
     </Container>
   )

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,38 +1,32 @@
-import * as React from 'react'
-import AppBar from '@mui/material/AppBar'
-import Box from '@mui/material/Box'
-import { CssBaseline } from '@mui/material'
-import Toolbar from '@mui/material/Toolbar'
-
+import React from 'react'
+import { AppBar, Box, CssBaseline, Toolbar } from '@mui/material'
 
 export const Navbar = () => {
     return (
-        <>
+        <Box sx={{ flexGrow: 1, width: '100vw' }}>
             <CssBaseline />
-            <Box sx={{ flexGrow: 1, width: '100vw' }}>
-                <AppBar position="static">
-                    <Toolbar sx={{ display: 'flex', justifyContent: 'space-between', bgcolor: "white" }}>
-                        <Box
-                            component="img"
-                            sx={{ maxHeight: { xs: 50, md: 60 }, margin: '10px', marginLeft: { xs: '10px', md: '24px'} }}
-                            alt="ECB logo. Dark blue: three lions passant under the crown"
-                            src="src/assets/ecbLogo.png"
-                        />
-                        <Box
-                            component="img"
-                            sx={{ maxHeight: { xs: 25, md: 40 }, margin: '10px' }}
-                            alt="Silly Ashes logo. Mid green icon of ball hitting stumps next to 'Silly Ashes'."
-                            src="src/assets/sillashesLogo.png"
-                        />
-                        <Box
-                            component="img"
-                            sx={{ maxHeight: { xs: 50, md: 60 }, margin: '10px', marginRight: { xs: '10px', md: '24px'} }}
-                            alt="Cricket Austraila emblem. Mid green shield with silver stars and a sun rising over the shadow of stumps."
-                            src="src/assets/ausLogo.png"
-                        />
-                    </Toolbar>
-                </AppBar>
-            </Box>
-        </>
-    );
+            <AppBar position="static">
+                <Toolbar sx={{ display: 'flex', justifyContent: 'space-between', bgcolor: "white" }}>
+                    <Box
+                        component="img"
+                        sx={{ maxHeight: { xs: 50, md: 60 }, margin: '10px', marginLeft: { xs: '10px', md: '24px' } }}
+                        alt="ECB logo. Dark blue: three lions passant under the crown"
+                        src="src/assets/ecbLogo.png"
+                    />
+                    <Box
+                        component="img"
+                        sx={{ maxHeight: { xs: 25, md: 40 }, margin: '10px' }}
+                        alt="Silly Ashes logo. Mid green icon of ball hitting stumps next to 'Silly Ashes'."
+                        src="src/assets/sillashesLogo.png"
+                    />
+                    <Box
+                        component="img"
+                        sx={{ maxHeight: { xs: 50, md: 60 }, margin: '10px', marginRight: { xs: '10px', md: '24px' } }}
+                        alt="Cricket Austraila emblem. Mid green shield with silver stars and a sun rising over the shadow of stumps."
+                        src="src/assets/ausLogo.png"
+                    />
+                </Toolbar>
+            </AppBar>
+        </Box>
+    )
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import AppBar from '@mui/material/AppBar'
+import Box from '@mui/material/Box'
+import { CssBaseline } from '@mui/material'
+import Toolbar from '@mui/material/Toolbar'
+
+
+export const Navbar = () => {
+    return (
+        <>
+            <CssBaseline />
+            <Box sx={{ flexGrow: 1, width: '100vw' }}>
+                <AppBar position="static">
+                    <Toolbar sx={{ display: 'flex', justifyContent: 'space-between', bgcolor: "white" }}>
+                        <Box
+                            component="img"
+                            sx={{ maxHeight: { xs: 50, md: 100 }, margin: { xs: '10px', md: '20px' } }}
+                            alt="ECB logo. Dark blue: three lions passant under the crown"
+                            src="src/assets/ecbLogo.png"
+                        />
+                        <Box
+                            component="img"
+                            sx={{ maxHeight: { xs: 25, md: 75 }, margin: { xs: '10px', md: '20px' } }}
+                            alt="Silly Ashes logo. Mid green icon of ball hitting stumps next to 'Silly Ashes'."
+                            src="src/assets/sillashesLogo.png"
+                        />
+                        <Box
+                            component="img"
+                            sx={{ maxHeight: { xs: 50, md: 100 }, margin: { xs: '10px', md: '20px' } }}
+                            alt="Cricket Austraila emblem. Mid green shield with silver stars and a sun rising over the shadow of stumps."
+                            src="src/assets/ausLogo.png"
+                        />
+                    </Toolbar>
+                </AppBar>
+            </Box>
+        </>
+    );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -14,19 +14,19 @@ export const Navbar = () => {
                     <Toolbar sx={{ display: 'flex', justifyContent: 'space-between', bgcolor: "white" }}>
                         <Box
                             component="img"
-                            sx={{ maxHeight: { xs: 50, md: 100 }, margin: { xs: '10px', md: '20px' } }}
+                            sx={{ maxHeight: { xs: 50, md: 60 }, margin: '10px', marginLeft: { xs: '10px', md: '24px'} }}
                             alt="ECB logo. Dark blue: three lions passant under the crown"
                             src="src/assets/ecbLogo.png"
                         />
                         <Box
                             component="img"
-                            sx={{ maxHeight: { xs: 25, md: 75 }, margin: { xs: '10px', md: '20px' } }}
+                            sx={{ maxHeight: { xs: 25, md: 40 }, margin: '10px' }}
                             alt="Silly Ashes logo. Mid green icon of ball hitting stumps next to 'Silly Ashes'."
                             src="src/assets/sillashesLogo.png"
                         />
                         <Box
                             component="img"
-                            sx={{ maxHeight: { xs: 50, md: 100 }, margin: { xs: '10px', md: '20px' } }}
+                            sx={{ maxHeight: { xs: 50, md: 60 }, margin: '10px', marginRight: { xs: '10px', md: '24px'} }}
                             alt="Cricket Austraila emblem. Mid green shield with silver stars and a sun rising over the shadow of stumps."
                             src="src/assets/ausLogo.png"
                         />


### PR DESCRIPTION
Added Navbar with provided logos, no links implemented at this stage, purely visual changes at this point.

- New directory `components` added to `src`, containing new `Navbar` component built using MUI AppBar.
- White AppBar background directly added within `sx` prop.
- Logos resize for screens larger/smaller than `md`, margins update accordingly.
- `Container` component within `App.jsx` edited to ensure nav width extends to viewport edges.