### PR TITLE
Harry/nav 2.0

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,7 @@
+.app-container {
+    min-height: 98svh;
+    width: 100%;
+    margin: 8px auto;
+    border-left: 5px solid rgb(21, 41, 94);
+    border-right: 5px solid rgb(0, 132, 61);
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { Container } from '@mui/material'
-import { BrowserRouter, Routes, Route  } from 'react-router-dom'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './App.css'
 
 import { Navbar } from './components/Navbar'
@@ -11,7 +11,7 @@ import { Player } from './pages/Player'
 function App() {
 
   return (
-    <Container disableGutters sx={{ margin: 0 }}>
+    <Container className='app-container' maxWidth='md'>
       <BrowserRouter>
 
         <Navbar />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,29 +1,16 @@
 import React from 'react'
-import { AppBar, Box, CssBaseline, Toolbar } from '@mui/material'
+import { AppBar, Box, Toolbar } from '@mui/material'
 
 export const Navbar = () => {
     return (
-        <Box sx={{ flexGrow: 1, width: '100vw' }}>
-            <CssBaseline />
-            <AppBar position="static">
+        <Box>
+            <AppBar position="static" sx={{ boxShadow: 0 }}>
                 <Toolbar sx={{ display: 'flex', justifyContent: 'space-between', bgcolor: "white" }}>
-                    <Box
-                        component="img"
-                        sx={{ maxHeight: { xs: 50, md: 60 }, margin: '10px', marginLeft: { xs: '10px', md: '24px' } }}
-                        alt="ECB logo. Dark blue: three lions passant under the crown"
-                        src="src/assets/ecbLogo.png"
-                    />
                     <Box
                         component="img"
                         sx={{ maxHeight: { xs: 25, md: 40 }, margin: '10px' }}
                         alt="Silly Ashes logo. Mid green icon of ball hitting stumps next to 'Silly Ashes'."
                         src="src/assets/sillashesLogo.png"
-                    />
-                    <Box
-                        component="img"
-                        sx={{ maxHeight: { xs: 50, md: 60 }, margin: '10px', marginRight: { xs: '10px', md: '24px' } }}
-                        alt="Cricket Austraila emblem. Mid green shield with silver stars and a sun rising over the shadow of stumps."
-                        src="src/assets/ausLogo.png"
                     />
                 </Toolbar>
             </AppBar>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,8 +3,7 @@ import { AppBar, Box, Toolbar } from '@mui/material'
 
 export const Navbar = () => {
     return (
-        <Box>
-            <AppBar position="static" sx={{ boxShadow: 0 }}>
+            <AppBar position="static" sx={{ boxShadow: 'none', bgcolor: 'rgb(0 0 0 / 0%)' }}>
                 <Toolbar sx={{ display: 'flex', justifyContent: 'space-between', bgcolor: "white" }}>
                     <Box
                         component="img"
@@ -14,6 +13,5 @@ export const Navbar = () => {
                     />
                 </Toolbar>
             </AppBar>
-        </Box>
     )
 }


### PR DESCRIPTION
Layout similar to original quiz app implemented:

![Screenshot 2023-07-08 at 14 10 07](https://github.com/mdnrosen/sillyashes-results/assets/109218783/5b011e88-60fb-4620-b349-52ede645c9ca)

Navbar:
- Team logos removed
- Box shadow removed
- No longer `100vw` wide

Main `Container` component in `App.jsx`:
- Max width set to `md` (960px)
- Borders added as per original Silly Ashes quiz app
- Margins re-established

Container component styled using `className` prop and `App.css`. I had initially done this through the `sx` prop but this became increasingly clumsy and cluttered - can revert to this approach if needed.