### PR TITLE
Harry/heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@600&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silly Ashes</title>
   </head>

--- a/src/assets/theme.js
+++ b/src/assets/theme.js
@@ -1,0 +1,14 @@
+import { createTheme } from "@mui/material"
+
+const theme = createTheme()
+
+theme.typography.h3 = {
+    fontSize: '0.85rem',
+    '@media (min-width:900px)': {
+        fontSize: '2rem',
+    },
+    fontFamily: ['Inter','sans-serif'].join(','),
+    fontWeight: 'normal'
+}
+
+export default theme

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Box } from '@mui/material'
 import { Link } from 'react-router-dom'
+import { HomeHeading } from './HomeHeading'
 
 
 export const Header = () => {
@@ -9,8 +10,9 @@ export const Header = () => {
             width: '100%',
             display: 'flex',
             flexWrap: 'wrap',
-            flexDirection: 'column',
-            justifyContent: 'space-between'
+            flexDirection: 'row',
+            justifyContent: { xs: 'left', md: 'space-between' },
+            alignItems: 'center'
         }}>
             <Box display={'flex'} justifyContent={'center'}>
                 <Link to={'/'}>
@@ -22,6 +24,7 @@ export const Header = () => {
                     />
                 </Link>
             </Box>
+            <HomeHeading />
         </Box >
     )
 }

--- a/src/components/HomeHeading.jsx
+++ b/src/components/HomeHeading.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, ThemeProvider, Typography } from '@mui/material'
-import theme from '../assets/theme'
+import theme from '../configs/theme'
 
 
 export const HomeHeading = () => {

--- a/src/components/HomeHeading.jsx
+++ b/src/components/HomeHeading.jsx
@@ -26,7 +26,8 @@ export const HomeHeading = () => {
                     sx={{
                         background: '-webkit-linear-gradient(right, #95ce39, #5fa92b, #337636, #4aa227)',
                         WebkitBackgroundClip: 'text',
-                        WebkitTextFillColor: 'transparent'
+                        WebkitTextFillColor: 'transparent',
+                        filter: { xs: 'blur(0.15px)', sm: '0.25px', md: '0.33px'}
                     }}
                 >
                     THE RESULTS

--- a/src/components/HomeHeading.jsx
+++ b/src/components/HomeHeading.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Box, createTheme, ThemeProvider, Typography } from '@mui/material'
+
+
+export const HomeHeading = () => {
+
+    const theme = createTheme()
+
+    theme.typography.h3 = {
+        fontSize: '1.2rem',
+        '@media (min-width:600px)': {
+            fontSize: '2.4rem',
+        },
+        fontFamily: 'sans-serif',
+        fontWeight: 'normal'
+    }
+
+
+    return (
+        <Box padding={2}>
+            <ThemeProvider theme={theme}>
+                <Typography
+                    textAlign={'center'}
+                    marginTop={1}
+                    variant='h3'
+                    sx={{
+                        background: '-webkit-linear-gradient(right, #95ce39, #5fa92b, #337636, #4aa227)',
+                        WebkitBackgroundClip: 'text',
+                        WebkitTextFillColor: 'transparent'
+                    }}
+                >
+                    SILLY ASHES - THE RESULTS
+                </Typography>
+            </ThemeProvider>
+        </Box>
+    )
+}

--- a/src/components/HomeHeading.jsx
+++ b/src/components/HomeHeading.jsx
@@ -1,19 +1,9 @@
 import React from 'react'
-import { Box, createTheme, ThemeProvider, Typography } from '@mui/material'
+import { Box, ThemeProvider, Typography } from '@mui/material'
+import theme from '../assets/theme'
 
 
 export const HomeHeading = () => {
-
-    const theme = createTheme()
-
-    theme.typography.h3 = {
-        fontSize: '0.85rem',
-        '@media (min-width:900px)': {
-            fontSize: '2rem',
-        },
-        fontFamily: ['Inter','sans-serif'].join(','),
-        fontWeight: 'normal'
-    }
 
 
     return (

--- a/src/components/HomeHeading.jsx
+++ b/src/components/HomeHeading.jsx
@@ -7,8 +7,8 @@ export const HomeHeading = () => {
     const theme = createTheme()
 
     theme.typography.h3 = {
-        fontSize: '1rem',
-        '@media (min-width:600px)': {
+        fontSize: '0.85rem',
+        '@media (min-width:900px)': {
             fontSize: '2rem',
         },
         fontFamily: ['Inter','sans-serif'].join(','),

--- a/src/components/HomeHeading.jsx
+++ b/src/components/HomeHeading.jsx
@@ -7,29 +7,29 @@ export const HomeHeading = () => {
     const theme = createTheme()
 
     theme.typography.h3 = {
-        fontSize: '1.2rem',
+        fontSize: '1rem',
         '@media (min-width:600px)': {
-            fontSize: '2.4rem',
+            fontSize: '2rem',
         },
-        fontFamily: 'sans-serif',
+        fontFamily: ['Inter','sans-serif'].join(','),
         fontWeight: 'normal'
     }
 
 
     return (
-        <Box padding={2}>
+        <Box padding={1}>
             <ThemeProvider theme={theme}>
                 <Typography
                     textAlign={'center'}
-                    marginTop={1}
                     variant='h3'
+                    gutterBottom
                     sx={{
                         background: '-webkit-linear-gradient(right, #95ce39, #5fa92b, #337636, #4aa227)',
                         WebkitBackgroundClip: 'text',
                         WebkitTextFillColor: 'transparent'
                     }}
                 >
-                    SILLY ASHES - THE RESULTS
+                    THE RESULTS
                 </Typography>
             </ThemeProvider>
         </Box>

--- a/src/configs/theme.js
+++ b/src/configs/theme.js
@@ -3,9 +3,10 @@ import { createTheme } from "@mui/material"
 const theme = createTheme()
 
 theme.typography.h3 = {
-    fontSize: '0.85rem',
+    fontSize: '0.8rem',
     '@media (min-width:900px)': {
-        fontSize: '2rem',
+        fontSize: '1rem',
+        paddingTop: '0.155rem'
     },
     fontFamily: ['Inter','sans-serif'].join(','),
     fontWeight: 'normal'

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,7 +5,6 @@ import { Box } from '@mui/material'
 import data from '../assets/dummyData.json'
 import dump from '../assets/dump.json'
 import { SearchToolbar } from '../components/SearchToolbar'
-import { HomeHeading } from '../components/HomeHeading'
 import markAll from '../utils/marking'
 
 
@@ -35,8 +34,6 @@ export const Home = () => {
 
     return (
         <Box sx={{ height: '100%', width: '100%' }}>
-
-            <HomeHeading />
 
             <SearchToolbar searchChangeHandler={searchChangeHandler} />
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -36,9 +36,10 @@ export const Home = () => {
     return (
         <Box sx={{ height: '100%', width: '100%' }}>
 
+            <HomeHeading />
+
             <SearchToolbar searchChangeHandler={searchChangeHandler} />
 
-            <HomeHeading />
 
             {filterPlayers().map(player => (
                 <Link to={`/${player.id}`} key={player.id}>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import { Box } from '@mui/material'
 import data from '../assets/dummyData.json'
 import dump from '../assets/dump.json'
 import { SearchToolbar } from '../components/SearchToolbar'
+import { HomeHeading } from '../components/HomeHeading'
 import markAll from '../utils/marking'
 
 
@@ -37,7 +38,7 @@ export const Home = () => {
 
             <SearchToolbar searchChangeHandler={searchChangeHandler} />
 
-            <h3>Silly Ashes - The results</h3>
+            <HomeHeading />
 
             {filterPlayers().map(player => (
                 <Link to={`/${player.id}`} key={player.id}>


### PR DESCRIPTION
Changed original unstyled `h3` element to MUI `<Typography` component, repositioned within `Header.jsx` next to logo.

Tried to match style from `sillashesLogo.png` as closely as possible:
- color gradient mimicked using Eye Dropper chrome extension to get colours from logo
- font matched using WhatTheFont

Font changes size responsively based on breakpoints, alignment within header flexbox changes on smaller/larger displays.

![Screenshot 2023-07-18 at 12 01 50](https://github.com/mdnrosen/sillyashes-results/assets/109218783/2664d543-3618-4be7-baf6-beec126ff6fe)

![Screenshot 2023-07-18 at 12 02 21](https://github.com/mdnrosen/sillyashes-results/assets/109218783/c2103105-7dc1-4fbe-a126-56e96f50744d)

_Tweaks required to either more closely match logo, or differentiate further - at present we are in a sort of uncanny point where the two are neither similar nor different enough to/from each other..._