### PR TITLE
layout for marking headtohead and multi kinda figured out

### DIFF
--- a/src/assets/answers.json
+++ b/src/assets/answers.json
@@ -1,315 +1,407 @@
 [
     {
-        "round" : {
+        "round": {
             "name": "Head to Head",
-            "number" : 1
+            "number": 1
         },
-        "questionNum" : 1,
+        "questionNum": 1,
         "questionName": "h2h_wickets_eng",
-        "answer" : ["Stuart Broad"] 
+        "question" : "Who will take more wickets?",
+        "answer": [
+            "Stuart Broad"
+        ],
+        "options": [
+            "Stuart Broad", "James Anderson"
+        ],
+        "questionTitle": "Old Dog vs the Older"
     },
     {
-        "round" : {
+        "round": {
             "name": "Head to Head",
-            "number" : 1
+            "number": 1
         },
-        "questionNum" : 2,
+        "questionNum": 2,
         "questionName": "h2h_wickets_aus",
-        "answer" : ["Pat Cummins"] 
+        "answer": [
+            "Pat Cummins"
+        ],
+        "options": [
+            "Pat Cummins", "Scott Boland"
+        ],
+        "questionTitle": "Skipper v Statue"
     },
     {
-        "round" : {
+        "round": {
             "name": "Head to Head",
-            "number" : 1
+            "number": 1
         },
-        "questionNum" : 3,
+        "questionNum": 3,
         "questionName": "h2h_wickets_pt",
-        "answer" : ["Joe Root"] 
+        "answer": [
+            "Joe Root"
+        ],
+        "options" : [
+            "Joe Root", "Marnus Labuschagne"
+        ],
+        
+        "questionTitle": "Part timers"
     },
     {
-        "round" : {
+        "round": {
             "name": "Head to Head",
-            "number" : 1
+            "number": 1
         },
-        "questionNum" : 4,
+        "questionNum": 4,
         "questionName": "h2h_catches",
-        "answer" : ["Joe Root"] 
+        "answer": [
+            "Joe Root"
+        ],
+        "options" : [
+            "Joe Root", "David Warner"
+        ],
+        "questionTitle": "Safe Hands"
     },
     {
-        "round" : {
+        "round": {
             "name": "Head to Head",
-            "number" : 1
+            "number": 1
         },
-        "questionNum" : 5,
+        "questionNum": 5,
         "questionName": "h2h_runs_eng",
-        "answer" : ["Joe Root"] 
+        "answer": [
+            "Joe Root"
+        ],
+        "options" : [
+            "Joe Root", "Harry Brook"
+        ],
+        "questionTitle": "Power or Precision"
     },
     {
-        "round" : {
+        "round": {
             "name": "Head to Head",
-            "number" : 1
+            "number": 1
         },
-        "questionNum" : 6,
+        "questionNum": 6,
         "questionName": "h2h_runs_aus",
-        "answer" : ["Steve Smith"] 
+        "answer": [
+            "Steve Smith"
+        ],
+        "options" : [
+            "Steve Smith", "Marnus Labuschagne"
+        ],
+        "questionTitle": "Master v Padawan"
     },
     {
-        "round" : {
+        "round": {
             "name": "Head to Head",
-            "number" : 1
+            "number": 1
         },
-        "questionNum" : 7,
+        "questionNum": 7,
         "questionName": "h2h_runs_bowlers",
-        "answer" : ["Stuart Broad"] 
+        "answer": [
+            "Stuart Broad"
+        ],
+        "options" : [
+            "Stuart Broad", "Nathan Lyon"
+        ],
+        "questionTitle": "Slogger"
     },
     {
-        "round" : {
+        "round": {
             "name": "Head to Head",
-            "number" : 1
+            "number": 1
         },
-        "questionNum" : 8,
+        "questionNum": 8,
         "questionName": "h2h_reviews",
-        "answer" : [ "Australia"] 
+        "answer": [
+            "Australia"
+        ],
+        "options" : [
+            "England", "Australia"
+        ],
+        "questionTitle": "Stay with your onfield decision"
     },
     {
-        "round" : {
+        "round": {
             "name": "Pick Em",
-            "number" : 2
+            "number": 2
         },
-        "questionNum" : 9,
+        "questionNum": 9,
         "questionName": "tons",
-        "answer" : ["Ben Stokes", "Usman Khawaja", "Joe Root", "Mitch Marsh", "Steve Smith", "Zak Crawley"] 
+        "answer": [
+            "Ben Stokes",
+            "Usman Khawaja",
+            "Joe Root",
+            "Mitch Marsh",
+            "Steve Smith",
+            "Zak Crawley"
+        ],
+        "questionTitle": "Ton Up"
     },
     {
-        "round" : {
+        "round": {
             "name": "Pick Em",
-            "number" : 2
+            "number": 2
         },
-        "questionNum" : 10,
+        "questionNum": 10,
         "questionName": "quack",
-        "answer" : ["Cameron Green", "Marnus Labuschagne"] 
+        "answer": [
+            "Cameron Green",
+            "Marnus Labuschagne"
+        ],
+        "questionTitle": "Quack Quack"
     },
     {
-        "round" : {
+        "round": {
             "name": "Pick Em",
-            "number" : 2
+            "number": 2
         },
-        "questionNum" : 11,
+        "questionNum": 11,
         "questionName": "5fers",
-        "answer" : ["Mark Wood", "Pat Cummins", "Mitchell Starc", "Chris Woakes"] 
+        "answer": [
+            "Mark Wood",
+            "Pat Cummins",
+            "Mitchell Starc",
+            "Chris Woakes"
+        ],
+        "questionTitle": "5-fers!"
     },
     {
-        "round" : {
+        "round": {
             "name": "Pick Em",
-            "number" : 2
+            "number": 2
         },
-        "questionNum" : 12,
-        "questionName": "bigHitters"
+        "questionNum": 12,
+        "questionName": "bigHitters",
+        "questionTitle": "Big Hitters"
     },
     {
-        "round" : {
+        "round": {
             "name": "Pick Em",
-            "number" : 2
+            "number": 2
         },
-        "questionNum" : 13,
-        "questionName": "fullStraight"
+        "questionNum": 13,
+        "questionName": "fullStraight",
+        "questionTitle": "Full & Straight"
     },
     {
-        "round" : {
+        "round": {
             "name": "Numbers",
-            "number" : 3
+            "number": 3
         },
-        "questionNum" : 14,
+        "questionNum": 14,
         "questionName": "num_playersTotal",
-        "answer" : 28
+        "answer": 28,
+        "questionTitle": "Rest & Rotate"
     },
     {
-        "round" : {
+        "round": {
             "name": "Numbers",
-            "number" : 3
+            "number": 3
         },
-        "questionNum" : 15,
+        "questionNum": 15,
         "questionName": "num_wk",
-        "answer" : 42
+        "answer": 42,
+        "questionTitle": "In the gloves"
     },
     {
-        "round" : {
+        "round": {
             "name": "Numbers",
-            "number" : 3
+            "number": 3
         },
-        "questionNum" : 16,
+        "questionNum": 16,
         "questionName": "num_stokesSR",
-        "answer" : 68
+        "answer": 68,
+        "questionTitle": "Go Hard"
     },
     {
-        "round" : {
+        "round": {
             "name": "Numbers",
-            "number" : 3
+            "number": 3
         },
-        "questionNum" : 17,
+        "questionNum": 17,
         "questionName": "num_spin",
-        "answer" : 33
+        "answer": 33,
+        "questionTitle": "Nice Garry"
     },
     {
-        "round" : {
+        "round": {
             "name": "Numbers",
-            "number" : 3
+            "number": 3
         },
-        "questionNum" : 18,
+        "questionNum": 18,
         "questionName": "num_elevenRuns",
-        "answer" : 29
+        "answer": 29,
+        "questionTitle": "Agar-ing it"
     },
     {
-        "round" : {
+        "round": {
             "name": "Multis",
-            "number" : 4
+            "number": 4
         },
-        "questionNum" : 19,
+        "questionNum": 19,
         "questionName": "m_warnerBroad",
-        "answer" : "2 - 3"
+        "answer": "2 - 3",
+        "questionTitle": "Broad's Bunny"
     },
     {
-        "round" : {
+        "round": {
             "name": "Multis",
-            "number" : 4
+            "number": 4
         },
-        "questionNum" : 20,
+        "questionNum": 20,
         "questionName": "m_venues",
-        "answer" : "Edgbaston"
+        "answer": "Edgbaston",
+        "questionTitle": "Road House"
     },
     {
-        "round" : {
+        "round": {
             "name": "Multis",
-            "number" : 4
+            "number": 4
         },
-        "questionNum" : 21,
+        "questionNum": 21,
         "questionName": "m_camGreen",
-        "answer" : "Batting Average"
+        "answer": "Batting Average",
+        "questionTitle": "All-round Aussie"
     },
     {
-        "round" : {
+        "round": {
             "name": "Multis",
-            "number" : 4
+            "number": 4
         },
-        "questionNum" : 22,
+        "questionNum": 22,
         "questionName": "m_firstInns",
-        "answer" : "300 - 349"
+        "answer": "300 - 349",
+        "questionTitle": "Runs on the board"
     },
     {
-        "round" : {
+        "round": {
             "name": "Multis",
-            "number" : 4
+            "number": 4
         },
-        "questionNum" : 23,
+        "questionNum": 23,
         "questionName": "m_afterThree",
-        "answer" : "2 - 1 Australia"
+        "answer": "2 - 1 Australia",
+        "questionTitle": "Scores on the doors"
     },
     {
-        "round" : {
+        "round": {
             "name": "Multis",
-            "number" : 4
+            "number": 4
         },
-        "questionNum" : 24,
+        "questionNum": 24,
         "questionName": "m_tailenders",
-        "answer" : "Caught Outfield"
+        "answer": "Caught Outfield",
+        "questionTitle": "Don't let the tail wag"
     },
     {
-        "round" : {
+        "round": {
             "name": "Multis",
-            "number" : 4
+            "number": 4
         },
-        "questionNum" : 25,
+        "questionNum": 25,
         "questionName": "m_retirement",
-        "answer" : "Neither"
+        "answer": "Neither",
+        "questionTitle": "End of an era?"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 26,
+        "questionNum": 26,
         "questionName": "tf_chase",
-        "answer" : "false"
+        "answer": "false",
+        "questionTitle": "Let's chase"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 27,
+        "questionNum": 27,
         "questionName": "tf_woakes",
-        "answer" : "true"
+        "answer": "true",
+        "questionTitle": "Woaksy is back"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 28,
+        "questionNum": 28,
         "questionName": "tf_20wickets",
-        "answer" : "false"
+        "answer": "false",
+        "questionTitle": "Roll Them"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 29,
+        "questionNum": 29,
         "questionName": "tf_nighthawk",
-        "answer" : "false"
+        "answer": "false",
+        "questionTitle": "Nighthawk"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 30,
+        "questionNum": 30,
         "questionName": "tf_batterDrop",
-        "answer" : "false"
+        "answer": "false",
+        "questionTitle": "Jason Roy'd"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 31,
+        "questionNum": 31,
         "questionName": "tf_moreThanBurns",
-        "answer" : "false"
+        "answer": "false",
+        "questionTitle": "Runs at the top"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 32,
+        "questionNum": 32,
         "questionName": "tf_bazBall",
-        "answer" : "true"
+        "answer": "true",
+        "questionTitle": "Baz Ball"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 33,
+        "questionNum": 33,
         "questionName": "tf_moeen",
-        "answer" : "false"
+        "answer": "false",
+        "questionTitle": "Return of the Beard"
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 34,
+        "questionNum": 34,
         "questionName": "tf_rootTon",
-        "answer" : "true"
+        "answer": "true",
+        "questionTitle": "It's been a while..."
     },
     {
-        "round" : {
+        "round": {
             "name": "True False",
-            "number" : 5
+            "number": 5
         },
-        "questionNum" : 35,
+        "questionNum": 35,
         "questionName": "tf_decided",
-        "answer" : "false"
+        "answer": "false",
+        "questionTitle": "Dead Rubber"
     }
 ]

--- a/src/configs/theme.js
+++ b/src/configs/theme.js
@@ -1,11 +1,12 @@
 import { createTheme } from "@mui/material"
 
 const theme = createTheme({
-    palette: {
-        text: {
-            primary: 'green'
-        }
-    }
+    // palette: {
+    //     text: {
+    //         primary: '#008000'
+    //     }
+    // },
+    // danger: 'red'
 })
 
 theme.typography.h3 = {

--- a/src/modules/SimpleRoundSummary.jsx
+++ b/src/modules/SimpleRoundSummary.jsx
@@ -63,7 +63,7 @@ export const SimpleRoundSummary = ({ questions }) => {
                         </ListItemAvatar>
                         <ListItemText 
                             primary={
-                                <Typography variant="h6">{q.questionTitle}</Typography>
+                                <Typography variant="body1">{q.questionTitle}</Typography>
                             }
                             secondary={
                                 q.question ?

--- a/src/modules/SimpleRoundSummary.jsx
+++ b/src/modules/SimpleRoundSummary.jsx
@@ -1,0 +1,94 @@
+import React from 'react'
+
+import { Chip, Accordion, AccordionDetails, AccordionSummary, Box, Typography, Toolbar, ListItem, ListItemAvatar, ListItemText, CircularProgress, Stack,   } from '@mui/material'
+import { ExpandMore, Check, Close } from '@mui/icons-material'
+
+
+
+
+export const SimpleRoundSummary = ({ questions }) => {
+
+    const score = questions.reduce((a, b) => a + b.points, 0)
+    console.log(`${score}/${questions.length * 5}`) 
+  return (
+    <Accordion>
+      <AccordionSummary
+        expandIcon={<ExpandMore />}
+      >
+        <Toolbar disableGutters>
+          <ListItem>
+            <ListItemAvatar>
+              <Typography variant="h6">
+                %%
+              </Typography>
+            </ListItemAvatar>
+            <ListItemText 
+              primary={
+                <Typography variant="h6">Round 1 - Head to Head</Typography>
+              }
+              secondary={
+                <Typography variant="overline">{score}/{questions.length * 5}</Typography>
+              }
+            />
+          </ListItem>
+        </Toolbar>
+
+      </AccordionSummary>
+      <AccordionDetails>
+        {questions.map(q => (
+            <Box key={q.questionName}>
+                <Toolbar disableGutters sx={{ p: 1, borderTop: '1px solid grey'}}>
+                    <ListItem
+                        secondaryAction={
+                            <Box sx={{ display: 'flex', alignItems: 'center'}}>
+
+                                {q.correct ?
+                                <Stack direction="row" alignItems="center" sx={{ color: 'success'}}>
+                                    <Check color="success"/>
+                                    <Typography sx={{ ml: 1, color: 'green' }}variant="body1">+5</Typography>
+                                </Stack>
+                                :
+                                <Stack direction="row" alignItems="center" sx={{ color: 'red'}}>
+                                    <Close color="red"/>
+                                    <Typography sx={{ ml: 1 }}variant="body1">0</Typography>
+                                </Stack>  
+                        }
+                            </Box>                      
+                        }
+                    >
+                        <ListItemAvatar>
+                            <Typography variant="h6">
+                                Q{q.questionNumber}
+                            </Typography>
+                        </ListItemAvatar>
+                        <ListItemText 
+                            primary={
+                                <Typography variant="h6">{q.questionTitle}</Typography>
+                            }
+                            secondary={
+                                q.question ?
+                                <Typography variant="body2">{q.question}</Typography>
+                                : null
+                            }
+                        />
+                    </ListItem>
+                </Toolbar>
+                <Toolbar>
+                    <Stack direction="row" spacing={2} justifyContent="space-between" sx={{ p: 1 }}>
+                        {q.options.map(opt => 
+                            <Chip 
+                                label={opt} 
+                                variant={q.guessed === opt ? 'contained' : 'outlined'}
+                                color={q.correctAnswer.includes(opt) ? 'success' : 'error'}
+                            />
+                        )}
+                    </Stack>
+                </Toolbar>
+            </Box>
+
+        ))}
+
+      </AccordionDetails>
+      </Accordion>
+  )
+}

--- a/src/pages/Player.jsx
+++ b/src/pages/Player.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState, useContext } from 'react'
-import { Accordion, AccordionSummary, AccordionDetails, Box, Toolbar, Typography, ListItem, ListItemAvatar, ListItemText } from '@mui/material'
+import { Accordion, AccordionSummary, AccordionDetails, Box, CircularProgress, Toolbar, Typography, ListItem, ListItemAvatar, ListItemText } from '@mui/material'
 import { useParams } from 'react-router-dom'
 import { PeopleContext } from '../App'
 import { Percentage } from '../components/Percentage'
 import { posSfx } from '../utils/helpers'
 
 import { ExpandMore } from '@mui/icons-material'
+import { SimpleRoundSummary } from '../modules/SimpleRoundSummary'
 
 
 
@@ -38,29 +39,11 @@ export const Player = () => {
           />
         </Typography>
       </Toolbar>
-      <Accordion>
-        <AccordionSummary
-        >
-          <Toolbar>
-            <ListItem>
-              <ListItemAvatar>
-                <Typography variant="h6">
-                  #1
-                </Typography>
-              </ListItemAvatar>
-              <ListItemText 
-                primary={
-                  <Typography variant="h6">Head to Head</Typography>
-                }
-                secondary={
-                  <Typography variant="body1">15/30</Typography>
-                }
-              />
-            </ListItem>
-          </Toolbar>
 
-        </AccordionSummary>
-        </Accordion>
+      
+      <SimpleRoundSummary 
+        questions={player.results.filter(p => p.roundNumber === 1)}
+      />
     </Box>
     ) : (
       <Box>

--- a/src/utils/marking.js
+++ b/src/utils/marking.js
@@ -12,18 +12,20 @@ const markAll = (person) => {
     const marking_simple = (answers) => {
         const { guesses } = person;
         const result = answers.map(ans => {
-            const { answer, questionName, questionNum, round } = ans
+            const { answer, questionName, questionNum, round, questionTitle, options } = ans
             const correct = guesses[questionName].includes(answer)
 
             return {
                 roundNumber: round.number,
                 roundName: round.name,
                 questionNumber: questionNum,
-                questionName: questionName,
+                questionName,
+                questionTitle,
                 guessed: guesses[questionName],
                 correctAnswer: answer,
                 points: correct ? 5 : 0,
-                correct
+                correct,
+                options
             }
         })
         return result
@@ -34,7 +36,7 @@ const markAll = (person) => {
         const { guesses } = person;
         const result = answers.map(ans => {
             let points = 0
-            const { answer, questionName, questionNum, round } = ans
+            const { answer, questionName, questionNum, round, questionTitle } = ans
             const guessed = guesses[questionName]
             if (questionName === 'tons' || questionName === '5fers') {
 
@@ -70,7 +72,8 @@ const markAll = (person) => {
                     roundNumber: round.number,
                     roundName: round.name,
                     questionNumber: questionNum,
-                    questionName: questionName,
+                    questionName,
+                    questionTitle,
                     guessed,
                     correctAnswer: answer,
                     points,
@@ -92,7 +95,8 @@ const markAll = (person) => {
                     roundNumber: round.number,
                     roundName: round.name,
                     questionNumber: questionNum,
-                    questionName: questionName,
+                    questionName,
+                    questionTitle,
                     guessed: picks,
                     points
                 }
@@ -107,7 +111,7 @@ const markAll = (person) => {
         const { guesses } = person;
         const result = answers.map(ans => {
             let points = 0
-            const { answer, questionName, questionNum, round } = ans
+            const { answer, questionName, questionNum, round, questionTitle } = ans
 
             const guessed = parseInt(guesses[questionName])
             if (between(guessed, minusPerc(answer, 0.15), addPerc(answer, 0.15))) {
@@ -125,7 +129,8 @@ const markAll = (person) => {
                 roundNumber: round.number,
                 roundName: round.name,
                 questionNumber: questionNum,
-                questionName: questionName,
+                questionName,
+                questionTitle,
                 guessed: guesses[questionName],
                 correctAnswer: answer,
                 points


### PR DESCRIPTION
- Commented out theme text as it was messing with marking colors. to be returned to
- added original 'options' to the marked object for use in marking (only for first round so far)
-  added 'questionTitle' to every question in marked object
- figured out layout for each question, header for player page is TBC and open to interpretation