### PR TITLE
Harry/section percentages

### DIFF
--- a/src/components/Percentage.jsx
+++ b/src/components/Percentage.jsx
@@ -6,12 +6,12 @@ import { setCircleStrokeColour } from '../utils/helpers'
 
 import './percentage.css'
 
-export const Percentage = ({ percent, percentile }) => {
+export const Percentage = ({ percent, percentile, width }) => {
     
     const circleColour = setCircleStrokeColour(percentile)
 
     return (
-        <Box position={'relative'} width={{ xs: '20%', sm: '15%', md: '12.5%' }}>
+        <Box position={'relative'} width={width}>
             <svg viewBox="0 0 36 36" className='circular-chart'>
                 <path
                     className='circle'

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -55,7 +55,7 @@ export const PlayerCard = ({ player }) => {
                 />
 
             </ListItem>
-            <Percentage percent={player.percent} percentile={player.positionPercentile} />
+            <Percentage width={{ xs: '20%', sm: '15%', md: '12.5%' }} percent={player.percent} percentile={player.positionPercentile} />
         </Box>
     </Link>
   )

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -9,7 +9,7 @@ import { trophyDisplay, posSfx } from '../utils/helpers'
 import { Percentage } from './Percentage'
 
 export const PlayerCard = ({ player }) => {
-    console.log(player)
+    
   return (
     <Link to={`/${player.id}`} key={player.id}>
         <Box

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -9,7 +9,7 @@ import { trophyDisplay, posSfx } from '../utils/helpers'
 import { Percentage } from './Percentage'
 
 export const PlayerCard = ({ player }) => {
-    
+
   return (
     <Link to={`/${player.id}`} key={player.id}>
         <Box

--- a/src/modules/PickRoundSummary.jsx
+++ b/src/modules/PickRoundSummary.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Chip, Accordion, AccordionDetails, AccordionSummary, Box, Typography, Toolbar, ListItem, ListItemAvatar, ListItemText, Stack } from '@mui/material'
 import { ExpandMore, Check, Close } from '@mui/icons-material'
+import { Percentage } from '../components/Percentage'
 
-export const PickRoundSummary = ({ questions }) => {
+export const PickRoundSummary = ({ questions, player }) => {
     const score = questions.reduce((a, b) => a + b.points, 0)
 
 
@@ -114,9 +115,7 @@ export const PickRoundSummary = ({ questions }) => {
             <Toolbar disableGutters>
                 <ListItem>
                 <ListItemAvatar>
-                    <Typography variant="h6">
-                    %%
-                    </Typography>
+                    <Percentage percent={player.percent} percentile={player.positionPercentile} />
                 </ListItemAvatar>
                 <ListItemText 
                     primary={

--- a/src/modules/PickRoundSummary.jsx
+++ b/src/modules/PickRoundSummary.jsx
@@ -6,6 +6,7 @@ import { Percentage } from '../components/Percentage'
 export const PickRoundSummary = ({ questions, player }) => {
     const score = questions.reduce((a, b) => a + b.points, 0)
 
+    const percentage = Math.round((score / (questions.length * 5)) * 100)
 
     const renderQuack = () => {
 
@@ -115,7 +116,7 @@ export const PickRoundSummary = ({ questions, player }) => {
             <Toolbar disableGutters>
                 <ListItem>
                 <ListItemAvatar>
-                    <Percentage percent={player.percent} percentile={player.positionPercentile} />
+                    <Percentage percent={percentage} percentile={percentage} />
                 </ListItemAvatar>
                 <ListItemText 
                     primary={

--- a/src/modules/PickRoundSummary.jsx
+++ b/src/modules/PickRoundSummary.jsx
@@ -2,11 +2,13 @@ import React from 'react'
 import { Chip, Accordion, AccordionDetails, AccordionSummary, Box, Typography, Toolbar, ListItem, ListItemAvatar, ListItemText, Stack } from '@mui/material'
 import { ExpandMore, Check, Close } from '@mui/icons-material'
 import { Percentage } from '../components/Percentage'
+import { getRoundPercentage } from '../utils/helpers'
+
 
 export const PickRoundSummary = ({ questions, player }) => {
     const score = questions.reduce((a, b) => a + b.points, 0)
 
-    const percentage = Math.round((score / (questions.length * 5)) * 100)
+    const percentage = getRoundPercentage(score, questions)
 
     const renderQuack = () => {
 
@@ -116,7 +118,14 @@ export const PickRoundSummary = ({ questions, player }) => {
             <Toolbar disableGutters>
                 <ListItem>
                 <ListItemAvatar>
-                    <Percentage percent={percentage} percentile={percentage} />
+                    {/* I'm not sure a percentage score works for Pick Round Summaries...? */}
+                    {/* Top/bottom scores result in values like 208% or -80% */}
+                    {/* Would a different, points gained, points lost work better? */}
+                    {/* e.g.: +45 / -30 */}
+                    <Percentage 
+                      percent={percentage} 
+                      percentile={percentage + 10} /* +10 is to provide greener colour for relatively lower scores */ 
+                    /> 
                 </ListItemAvatar>
                 <ListItemText 
                     primary={
@@ -125,6 +134,7 @@ export const PickRoundSummary = ({ questions, player }) => {
                     </Typography>
                     }
                     secondary={
+                    // see above: does score / number of questions work? You see values like 51/25 or -20/25...
                     <Typography variant="body1">{score}/{questions.length * 5}</Typography>
                     }
                 />

--- a/src/modules/SimpleRoundSummary.jsx
+++ b/src/modules/SimpleRoundSummary.jsx
@@ -9,6 +9,9 @@ import { PercentageSimple } from '../components/PercentageSimple'
 export const SimpleRoundSummary = ({ questions, player }) => {
 
     const score = questions.reduce((a, b) => a + b.points, 0)
+
+  const percentage = Math.round((score / (questions.length * 5)) * 100)
+
   return (
     <Accordion sx={{ m: 2}}>
       <AccordionSummary
@@ -17,7 +20,7 @@ export const SimpleRoundSummary = ({ questions, player }) => {
         <Toolbar disableGutters>
           <ListItem>
             <ListItemAvatar >
-                <Percentage percent={player.percent} percentile={player.positionPercentile} />
+                <Percentage percent={percentage} percentile={percentage + 10} />
             </ListItemAvatar>
             <ListItemText 
               primary={

--- a/src/modules/SimpleRoundSummary.jsx
+++ b/src/modules/SimpleRoundSummary.jsx
@@ -3,14 +3,13 @@ import React from 'react'
 import { Chip, Accordion, AccordionDetails, AccordionSummary, Box, Typography, Toolbar, ListItem, ListItemAvatar, ListItemText, Stack } from '@mui/material'
 import { ExpandMore, Check, Close } from '@mui/icons-material'
 import { Percentage } from '../components/Percentage'
-import { PercentageSimple } from '../components/PercentageSimple'
-
+import { getRoundPercentage } from '../utils/helpers'
 
 export const SimpleRoundSummary = ({ questions, player }) => {
 
     const score = questions.reduce((a, b) => a + b.points, 0)
 
-  const percentage = Math.round((score / (questions.length * 5)) * 100)
+  const percentage = getRoundPercentage(score, questions)
 
   return (
     <Accordion sx={{ m: 2}}>
@@ -20,7 +19,10 @@ export const SimpleRoundSummary = ({ questions, player }) => {
         <Toolbar disableGutters>
           <ListItem>
             <ListItemAvatar >
-                <Percentage percent={percentage} percentile={percentage + 10} />
+                <Percentage 
+                  percent={percentage} 
+                  percentile={percentage + 10} /* +10 is to provide greener colour for relatively lower scores */ 
+                /> 
             </ListItemAvatar>
             <ListItemText 
               primary={

--- a/src/modules/SimpleRoundSummary.jsx
+++ b/src/modules/SimpleRoundSummary.jsx
@@ -6,7 +6,7 @@ import { Percentage } from '../components/Percentage'
 import { PercentageSimple } from '../components/PercentageSimple'
 
 
-export const SimpleRoundSummary = ({ questions }) => {
+export const SimpleRoundSummary = ({ questions, player }) => {
 
     const score = questions.reduce((a, b) => a + b.points, 0)
   return (
@@ -16,10 +16,8 @@ export const SimpleRoundSummary = ({ questions }) => {
       >
         <Toolbar disableGutters>
           <ListItem>
-            <ListItemAvatar>
-              <Typography variant="h6">
-                %%
-              </Typography>
+            <ListItemAvatar >
+                <Percentage percent={player.percent} percentile={player.positionPercentile} />
             </ListItemAvatar>
             <ListItemText 
               primary={

--- a/src/pages/Player.jsx
+++ b/src/pages/Player.jsx
@@ -35,6 +35,7 @@ export const Player = () => {
         {posSfx(player.position)}
         </Typography>
           <Percentage
+            width={{ xs: '20%', sm: '15%', md: '12.5%' }}
             percent={player.percent}
             percentile={player.positionPercentile}
           />

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -79,3 +79,7 @@ export const trophyDisplay = position => {
     trophy.display = true
     return trophy
 }
+
+export const getRoundPercentage = (score, questions) => {
+    return Math.round((score / (questions.length * 5)) * 100)
+}


### PR DESCRIPTION
`<Percentage />` component now renders within round summaries:

![Screenshot 2023-07-23 at 17 18 40](https://github.com/mdnrosen/sillyashes-results/assets/109218783/486d99b1-fd3c-49be-ae7b-2b9d04cfdc80)

- some tweaks to formatting required for smaller screens (`...RoundSummary` components as a whole need updating for smaller screens, I think?). 
- Does a percentage (and indeed a score/questions) work for Pick rounds? Comments added to this effect
- Percentage component display colour calculated using a fairly blunt method (`setCircleStrokeColour`, with `percentage + 10` passed in - gives greenest green for scores of 80%+ and red for scores under 0)  ...would a slightly more nuanced approach yield a noticeable improvement or does this do the job?
